### PR TITLE
Fix build with newer toolchains

### DIFF
--- a/mv_ddr4_mpr_pda_if.c
+++ b/mv_ddr4_mpr_pda_if.c
@@ -705,11 +705,11 @@ int mv_ddr4_pda_pattern_odpg_load(u32 dev_num, enum hws_access_type access_type,
 	if (status != MV_OK)
 		return status;
 
-	if (subphy_mask != 0xf)
+	if (subphy_mask != 0xf) {
 		for (subphy_num = 0; subphy_num < 4; subphy_num++)
 			if (((subphy_mask >> subphy_num) & 0x1) == 0)
 				data_low[0] = (data_low[0] | (0xff << (subphy_num * 8)));
-	else
+	} else
 		data_low[0] = 0;
 
 	for (pattern_len_count = 0; pattern_len_count < 4; pattern_len_count++) {


### PR DESCRIPTION
Newer toolchains (gcc 7.2 and clang 5.0) issue a warning about
ambiguous else statements, triggered by code built with
-Werror -- resulting in

mv_ddr4_mpr_pda_if.c: In function ‘mv_ddr4_pda_pattern_odpg_load’:
mv_ddr4_mpr_pda_if.c:708:5: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=parentheses]

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>