### PR TITLE
mv_ddr: a38x: use non-zero size for ddr scrubbing

### DIFF
--- a/a38x/mv_ddr_plat.c
+++ b/a38x/mv_ddr_plat.c
@@ -1211,7 +1211,7 @@ static u32 ddr3_get_device_size(u32 cs)
 	}
 }
 
-static int ddr3_calc_mem_cs_size(u32 cs, uint64_t *cs_size)
+int ddr3_calc_mem_cs_size(u32 cs, uint64_t *cs_size)
 {
 	u32 cs_mem_size;
 

--- a/a38x/mv_ddr_plat.h
+++ b/a38x/mv_ddr_plat.h
@@ -337,4 +337,5 @@ u32 mv_ddr_dm_pad_get(void);
 int mv_ddr_pre_training_fixup(void);
 int mv_ddr_post_training_fixup(void);
 int mv_ddr_manual_cal_do(void);
+int ddr3_calc_mem_cs_size(u32 cs, uint64_t *cs_size);
 #endif /* _MV_DDR_PLAT_H */

--- a/xor.c
+++ b/xor.c
@@ -439,6 +439,9 @@ void ddr3_new_tip_ecc_scrub(void)
 	for (cs_c = 0; cs_c < max_cs; cs_c++)
 		cs_ena |= 1 << cs_c;
 
+	/* assume that all CS have same size */
+	ddr3_calc_mem_cs_size(0, &cs_mem_size);
+
 	mv_sys_xor_init(max_cs, cs_ena, cs_mem_size, 0);
 	total_mem_size = max_cs * cs_mem_size;
 	mv_xor_mem_init(0, 0, total_mem_size, 0xdeadbeef, 0xdeadbeef);


### PR DESCRIPTION
Make ddr3_calc_mem_cs_size() global scope and use it in
ddr3_new_tip_ecc_scrub to correctly initialize all of DDR memory.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>