### PR TITLE
fix compiler warning in mv_ddr4_dynamic_pb_wl_supp

### DIFF
--- a/mv_ddr4_training_leveling.c
+++ b/mv_ddr4_training_leveling.c
@@ -447,15 +447,16 @@ static int mv_ddr4_dynamic_pb_wl_supp(u32 dev_num, enum mv_wl_supp_mode ecc_mode
 				} else { /* shift phase to -1 */
 					step++;
 					if (step == 1) { /* set phase (0x0[6-8]) to -2 */
-						if (orig_phase > 1)
-							wr_data = (rd_data & ~0x1c0) | ((orig_phase - 2) << 6);
-						else if (orig_phase == 1)
+						if (orig_phase >= 1) {
+							if (orig_phase > 1)
+								wr_data = (rd_data & ~0x1c0) | ((orig_phase - 2) << 6);
+							else
 								wr_data = (rd_data & ~0x1df);
-						if (orig_phase >= 1)
 							ddr3_tip_bus_write(dev_num, ACCESS_TYPE_UNICAST, if_id,
 									   ACCESS_TYPE_UNICAST, subphy_num,
 									   DDR_PHY_DATA,
 									   WL_PHY_REG(effective_cs), wr_data);
+						}
 					} else if (step == 2) { /* shift phase to +1 */
 						if (orig_phase <= 5) {
 							wr_data = (rd_data & ~0x1c0) | ((orig_phase + 2) << 6);


### PR DESCRIPTION
The variable orig_phase is local and nonvolatile and can't change
during the assignments, gcc-5.4 had problems seeing the if branches
cover all the cases for wr_data, this rearrangement is logically the same
but does not require declaring wr_data uninitialized.