### PR TITLE
mv_ddr: ddr3: fix tRAS timimg parameter

### DIFF
--- a/ddr3_training_db.c
+++ b/ddr3_training_db.c
@@ -614,13 +614,13 @@ unsigned int mv_ddr_speed_bin_timing_get(enum mv_ddr_speed_bin index, enum mv_dd
 		result = speed_bin_table_t_rcd_t_rp[index];
 		break;
 	case SPEED_BIN_TRAS:
-		if (index < SPEED_BIN_DDR_1066G)
+		if (index <= SPEED_BIN_DDR_1066G)
 			result = 37500;
-		else if (index < SPEED_BIN_DDR_1333J)
+		else if (index <= SPEED_BIN_DDR_1333J)
 			result = 36000;
-		else if (index < SPEED_BIN_DDR_1600K)
+		else if (index <= SPEED_BIN_DDR_1600K)
 			result = 35000;
-		else if (index < SPEED_BIN_DDR_1866M)
+		else if (index <= SPEED_BIN_DDR_1866M)
 			result = 34000;
 		else
 			result = 33000;


### PR DESCRIPTION
Based on the JEDEC standard JESD79-3F. The tRAS timings should include
the highest speed bins at a given frequency. This is similar to commit
683c67b ("mv_ddr: ddr3: fix tfaw timimg parameter") where the
wrong comparison was used in the initial implementation.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>