### PR TITLE
mv_ddr: ddr3: only use active chip-selects when tuning ODT

### DIFF
--- a/ddr3_training_hw_algo.c
+++ b/ddr3_training_hw_algo.c
@@ -142,6 +142,7 @@ int ddr3_tip_write_additional_odt_setting(u32 dev_num, u32 if_id)
 	int max_phase = MIN_VALUE, current_phase;
 	enum hws_access_type access_type = ACCESS_TYPE_UNICAST;
 	u32 octets_per_if_num = ddr3_tip_dev_attr_get(dev_num, MV_ATTR_OCTET_PER_INTERFACE);
+	unsigned int max_cs = mv_ddr_cs_num_get();
 
 	CHECK_STATUS(ddr3_tip_if_write(dev_num, access_type, if_id,
 				       DUNIT_ODT_CTRL_REG,
@@ -151,7 +152,7 @@ int ddr3_tip_write_additional_odt_setting(u32 dev_num, u32 if_id)
 				      data_read, MASK_ALL_BITS));
 	val = data_read[if_id];
 
-	for (cs_num = 0; cs_num < MAX_CS_NUM; cs_num++) {
+	for (cs_num = 0; cs_num < max_cs; cs_num++) {
 		read_sample[cs_num] = GET_RD_SAMPLE_DELAY(val, cs_num);
 
 		/* find maximum of read_samples */


### PR DESCRIPTION
On boards with particularly short traces the read sampling can end up 0
which can end up configuring an excessively long ODT read delay due to
the integer underflow of 'min_read_sample - 1'.  When the read sampling
in ddr3_tip_write_additional_odt_setting gets a value lower than cas_l
make cas_l the minimum.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>