### PR TITLE
cn913x: Add cn913x_cex7_eval config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,14 @@ MV_DDR_SNPS = y
 MV_DDR_FLOW_V2 = y
 endif
 
+ifneq ($(findstring cn913x_cex7_eval, $(PLATFORM)),)
+CFLAGS += -DCONFIG_64BIT -DCONFIG_MC6P -DAPN807
+CFLAGS += -DT9130
+MV_DDR_PLAT = apn807
+MV_DDR_SNPS = y
+MV_DDR_FLOW_V2 = y
+endif
+
 ifneq ($(findstring a8xx,$(PLATFORM)),)
 CFLAGS += -DCONFIG_MC6P
 MV_DDR_PLAT = apn810


### PR DESCRIPTION
This patch adds the new config to support
the SolidRun CN913X CEx7 Evaluation Board.