### PR TITLE
mv_ddr: a38x: fix SPLIT_OUT_MIX and BYTE_HOMOGENEOUS_SPLIT_OUT decision

### DIFF
--- a/ddr3_training_centralization.c
+++ b/ddr3_training_centralization.c
@@ -153,6 +153,7 @@ static int ddr3_tip_centralization(u32 dev_num, u32 mode)
 	enum hws_training_ip_stat training_result[MAX_INTERFACE_NUM];
 	u32 if_id, pattern_id, bit_id;
 	u8 bus_id;
+	u8 current_byte_status;
 	u8 cur_start_win[BUS_WIDTH_IN_BITS];
 	u8 centralization_result[MAX_INTERFACE_NUM][BUS_WIDTH_IN_BITS];
 	u8 cur_end_win[BUS_WIDTH_IN_BITS];
@@ -264,6 +265,10 @@ static int ddr3_tip_centralization(u32 dev_num, u32 mode)
 						  result[search_dir_id][7]));
 				}
 
+				current_byte_status =
+					mv_ddr_tip_sub_phy_byte_status_get(if_id,
+									   bus_id);
+
 				for (bit_id = 0; bit_id < BUS_WIDTH_IN_BITS;
 				     bit_id++) {
 					/* check if this code is valid for 2 edge, probably not :( */
@@ -272,11 +277,32 @@ static int ddr3_tip_centralization(u32 dev_num, u32 mode)
 							       [HWS_LOW2HIGH]
 							       [bit_id],
 							       EDGE_1);
+					if (current_byte_status &
+					    BYTE_SPLIT_OUT_MIX) {
+						if (cur_start_win[bit_id] >= 64)
+							cur_start_win[bit_id] -= 64;
+						else
+							cur_start_win[bit_id] = 0;
+						DEBUG_CENTRALIZATION_ENGINE
+							(DEBUG_LEVEL_INFO,
+							 ("pattern %d IF %d pup %d bit %d subtract 64 adll from start\n",
+							  pattern_id, if_id, bus_id, bit_id));
+					}
 					cur_end_win[bit_id] =
 						GET_TAP_RESULT(result
 							       [HWS_HIGH2LOW]
 							       [bit_id],
 							       EDGE_1);
+					if (cur_end_win[bit_id] >= 64 &&
+					    (current_byte_status &
+					     BYTE_SPLIT_OUT_MIX)) {
+						cur_end_win[bit_id] -= 64;
+						DEBUG_CENTRALIZATION_ENGINE
+							(DEBUG_LEVEL_INFO,
+							 ("pattern %d IF %d pup %d bit %d subtract 64 adll from end\n",
+							  pattern_id, if_id, bus_id, bit_id));
+					}
+
 					/* window length */
 					current_window[bit_id] =
 						cur_end_win[bit_id] -

--- a/ddr3_training_centralization.c
+++ b/ddr3_training_centralization.c
@@ -278,7 +278,8 @@ static int ddr3_tip_centralization(u32 dev_num, u32 mode)
 							       [bit_id],
 							       EDGE_1);
 					if (current_byte_status &
-					    BYTE_SPLIT_OUT_MIX) {
+					    (BYTE_SPLIT_OUT_MIX |
+					     BYTE_HOMOGENEOUS_SPLIT_OUT)) {
 						if (cur_start_win[bit_id] >= 64)
 							cur_start_win[bit_id] -= 64;
 						else
@@ -295,7 +296,8 @@ static int ddr3_tip_centralization(u32 dev_num, u32 mode)
 							       EDGE_1);
 					if (cur_end_win[bit_id] >= 64 &&
 					    (current_byte_status &
-					     BYTE_SPLIT_OUT_MIX)) {
+					     (BYTE_SPLIT_OUT_MIX |
+					      BYTE_HOMOGENEOUS_SPLIT_OUT))) {
 						cur_end_win[bit_id] -= 64;
 						DEBUG_CENTRALIZATION_ENGINE
 							(DEBUG_LEVEL_INFO,


### PR DESCRIPTION
These two mv-ddr patches from Marek Behún (@elkablo) were included into U-Boot repository:
* https://source.denx.de/u-boot/u-boot/-/commit/3fc92a215b69ad448c151489228eb340df9a8703
* https://source.denx.de/u-boot/u-boot/-/commit/a163db9fbaa9004bc461d8b1c6b648c674c25f09
___

This is a cleaned up and fixed version of a patch
  mv_ddr: a380: fix SPLIT_OUT_MIX state decision

  in each pattern cycle the bus state can be changed
  in order to avoide it, need to back to the same bus state on each
  pattern cycle
by
  Moti Boskula <motib@marvell.com>

The original patch is not in Marvell's mv-ddr-marvell repository. It was
gives to us by Marvell to fix an issues with DDR training on some
boards, but it cannot be applied as is to mv-ddr-marvell, because it is
a very dirty draft patch that would certainly break other things, mainly
DDR4 training code in mv-ddr-marvell, since it changes common functions.

I have cleaned up the patch and removed stuff that seemed unnecessary
(when removed, it still fixed things). Note that I don't understand
completely what the code does exactly, since I haven't studied the DDR
training code extensively (and I suspect that no one besides some few
people in Marvell understand the code completely).

Anyway after the cleanup the patch still fixes isssues with DDR training
on the failing boards.

There was also a problem with the original patch on some of the Allied
Telesis' x530 boards, reported by Chris Packham. I have asked Chris to
send me some logs, and managed to fix it:
- if you look at the change, you'll notice that it introduces
  subtraction of cur_start_win[] and cur_end_win[] members, depending on
  a bit set in the current_byte_status variable
- the original patch subtracted cur_start_win[] if either
  BYTE_SPLIT_OUT_MIX or BYTE_HOMOGENEOUS_SPLIT_OUT bits were set, but
  subtracted cur_end_win[] only if the first one (BYTE_SPLIT_OUT_MIX)
  was set
- from Chris Packham logs I discovered that the x530 board where the
  original patch introduced DDR training failure, only the
  BYTE_HOMOGENEOUS_SPLIT_OUT bit was set, and on our boards where the
  patch is needed only the BYTE_SPLIT_OUT_MIX is set in the
  current_byte_status variable
- this led me to the hypothesis that both cur_start_win[] and
  cur_end_win[] should be subtracted only if BYTE_SPLIT_OUT_MIX bit is
  set, the BYTE_HOMOGENEOUS_SPLIT_OUT bit shouldn't be considered at all
- this hypothesis also gains credibility when considering the commit
  title ("fix SPLIT_OUT_MIX state decision")

Hopefully this will fix things without breaking anything else.

___

 mv_ddr: a38x: fix BYTE_HOMOGENEOUS_SPLIT_OUT decision

In commit "ddr: marvell: a38x: fix SPLIT_OUT_MIX state decision"
I ported a cleaned up and changed version of patch
  mv_ddr: a380: fix SPLIT_OUT_MIX state decision

In the port we removed checking for BYTE_HOMOGENEOUS_SPLIT_OUT bit,
because:
- the fix seemed to work without it
- the bit was checked for only at one place out of two, while the second
  bit, BYTE_SPLIT_OUT_MIX, was checked for in both cases
- without the removal it didn't work on Allied Telesis' x530 board

We recently had a chance to test on more boards, and it seems that the
change needs to be opposite: instead of removing the check for
BYTE_HOMOGENEOUS_SPLIT_OUT from the first if() statement, the check
needs to be added also to the second one - it needs to be at both
places.

With this change all the Turris Omnia boards I have had available to
test seem to work, I didn't encounter not even one failed DDR training.

As last time, I am noting that I do not understand what this code is
actually doing, I haven't studied the DDR training algorithm and
I suspect that no one will be able to explain it to U-Boot contributors,
so we are left with this blind poking in the code with testing whether
it works on several boards and hoping it doesn't break anything for
anyone :-(.