### PR TITLE
mv_ddr: a3700: Use the right size for memset to not overflow

### DIFF
--- a/a3700/a3700_tool.c
+++ b/a3700/a3700_tool.c
@@ -327,7 +327,7 @@ static int ddr_cfg_read(FILE *fp, struct config_item *cfg_list, int num)
 				if (strcmp(key, cfg_list[i].key) == 0)
 					strcpy(cfg_list[i].value, value);
 			}
-			memset(key, 0, MAX_CFG_LINE_LEN);
+			memset(key, 0, MAX_CFG_NAME_LEN);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/MarvellEmbeddedProcessors/mv-ddr-marvell/issues/37