### PR TITLE
Fixes compile errors for ddr4 a38x in U-Boot

### DIFF
--- a/a38x/mv_ddr_plat.c
+++ b/a38x/mv_ddr_plat.c
@@ -1676,12 +1676,12 @@ int ddr3_tip_configure_phy(u32 dev_num)
  * this function validates the calibration values
  * the function is per soc due to the different processes the calibration values are different
  */
-MV_STATUS mv_ddr4_calibration_validate(MV_U32 dev_num)
+int mv_ddr4_calibration_validate(u32 dev_num)
 {
-	MV_STATUS status = MV_OK;
-	MV_U8 if_id = 0;
-	MV_U32 read_data[MAX_INTERFACE_NUM];
-	MV_U32 cal_n = 0, cal_p = 0;
+	int status = MV_OK;
+	u8 if_id = 0;
+	u32 read_data[MAX_INTERFACE_NUM];
+	u32 cal_n = 0, cal_p = 0;
 
 	/*
 	 * Pad calibration control enable: during training set the calibration to be internal

--- a/mv_ddr4_training_calibration.c
+++ b/mv_ddr4_training_calibration.c
@@ -806,7 +806,7 @@ static int mv_ddr4_copt_get(u8 dir, u16 *lambda, u8 *vw_l, u8 *vw_h, u8 *pbs_res
 	/* lambda calculated as D * PBS_VALUE_FACTOR / d */
 	//printf("Copt::Debug::\t");
 	for (dq_idx = 0; dq_idx < 8; dq_idx++) {
-		center_per_dq[dq_idx] = 0.5 * (vw_h[dq_idx] + vw_l[dq_idx]);
+		center_per_dq[dq_idx] = (vw_h[dq_idx] + vw_l[dq_idx]) / 2;
 		vw_per_dq[dq_idx] = 1 + (vw_h[dq_idx] - vw_l[dq_idx]);
 		if (min_vw > vw_per_dq[dq_idx])
 			min_vw = vw_per_dq[dq_idx];
@@ -846,9 +846,9 @@ static int mv_ddr4_copt_get(u8 dir, u16 *lambda, u8 *vw_l, u8 *vw_h, u8 *pbs_res
 		return MV_OK;
 	} else { /* not center zone visib */
 		for (dq_idx = 0; dq_idx < 8; dq_idx++) {
-			if ((center_zone_low[dq_idx] + 1) > (0.5 * vw_per_dq[dq_idx] + vw_per_dq[dq_idx] % 2)) {
+			if ((center_zone_low[dq_idx] + 1) > (vw_per_dq[dq_idx] / 2  + vw_per_dq[dq_idx] % 2)) {
 				vw_zone_low[dq_idx] = (center_zone_low[dq_idx] + 1) -
-						      (0.5 * vw_per_dq[dq_idx] + vw_per_dq[dq_idx] % 2);
+						      (vw_per_dq[dq_idx] / 2 + vw_per_dq[dq_idx] % 2);
 			} else {
 				vw_zone_low[dq_idx] = 0;
 				DEBUG_CALIBRATION(DEBUG_LEVEL_INFO,
@@ -859,7 +859,7 @@ static int mv_ddr4_copt_get(u8 dir, u16 *lambda, u8 *vw_l, u8 *vw_h, u8 *pbs_res
 						   vw_l[dq_idx], vw_h[dq_idx], lambda[dq_idx]));
 			}
 
-			vw_zone_high[dq_idx] = center_zone_high[dq_idx] + 0.5 * vw_per_dq[dq_idx];
+			vw_zone_high[dq_idx] = center_zone_high[dq_idx] + vw_per_dq[dq_idx] / 2;
 
 			if (vw_zone_max_low < vw_zone_low[dq_idx])
 				vw_zone_max_low = vw_zone_low[dq_idx];
@@ -1213,7 +1213,7 @@ static int mv_ddr4_tap_tuning(u8 dev, u16 (*pbs_tap_factor)[MAX_BUS_NUM][BUS_WID
 	int dq_to_dqs_min_delta = dq_to_dqs_min_delta_threshold * 2;
 	u32 pbs_tap_factor0 = PBS_VAL_FACTOR * NOMINAL_PBS_DLY / adll_tap; /* init lambda */
 	/* adapt pbs to frequency */
-	u32 new_pbs = (18100 - (3.45 * freq)) / 1000;
+	u32 new_pbs = (1810000 - (345 * freq)) / 100000;
 	int stage_num, loop;
 	int wl_tap, new_wl_tap;
 	int pbs_tap_factor_avg;


### PR DESCRIPTION
Upstream U-Boot project contains some a38x patch which fixes compile errors for ddr4 a38x.
- Modify mv_ddr4_calibration_validate function body to match function header.
- Convert floating point operations to integer operations.