### PR TITLE
Perform DDR training sequence again for 2nd boot

### DIFF
--- a/a38x/mv_ddr_plat.c
+++ b/a38x/mv_ddr_plat.c
@@ -1463,13 +1463,6 @@ int mv_ddr_pre_training_soc_config(const char *ddr_type)
 			    DRAM_RESET_MASK_MASKED << DRAM_RESET_MASK_OFFS);
 	}
 
-	/* Check if DRAM is already initialized  */
-	if (reg_read(REG_BOOTROM_ROUTINE_ADDR) &
-	    (1 << REG_BOOTROM_ROUTINE_DRAM_INIT_OFFS)) {
-		printf("%s Training Sequence - 2nd boot - Skip\n", ddr_type);
-		return MV_OK;
-	}
-
 	/* Fix read ready phases for all SOC in reg 0x15c8 */
 	reg_val = reg_read(TRAINING_DBG_3_REG);
 


### PR DESCRIPTION
Upstream U-Boot project contains some a38x patch which improves the robustness of DDR training.

- DDR Training sequence happens very fast. The speedup in boot time is negligible by skipping the training sequence during 2nd boot or after. So remove the check and skip.

- This change improves the robustness of DDR training. If u-boot crashed during DDR training, the training could be left in a limbo state, where the BootROM has recorded that it is already in a 2nd boot. The training must be repeated in this scenario to get out of this limbo state, but due to the check it cannot be performed.

- Background:

I did have such a crash recently when I was testing the combination of LTO and Thumb configs on the Thecus N2350 board (Armada 385). And apparently it crashed during the DDR4 training in SPL. A power recycle always results in the board hung at the same place right after the DDR training was skipped.

mv_ddr: 14.0.0
DDR4 Training Sequence - 2nd boot - Skip
max poll IF #0
polling failed IF 0
DDR3 init_sequence - FAILED 0x1
max poll IF #0
polling failed IF 0
mv_ddr_is_training_done: timeout

So that led me to the DDR code that performs the check for 2nd boot. And forcing DDR training to run again (using kwboot) fixed the problem and the board can be booted normally again. And the DDR training time is as fast as previously when it was skipped during 2nd boot.

Reference:
https://github.com/mibodhi/u-boot/commit/6add83991b2887619d0b25e4068b4c0082a4596a