### PR TITLE
a3700: change DDR4 1CS 1GB PHY drive strength to 40 ohms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+a3700_ddr_type
+a3700_tool
+*.o
+mv_ddr_build_message.c

--- a/a3700/mv_ddr_tim.h
+++ b/a3700/mv_ddr_tim.h
@@ -354,7 +354,7 @@ static char ddr4_1cs_tim_post[] = {
 	"DELAY: 0x0000000A\n"
 	"\n"
 	";Step9: DDRPHY Driver/Receiver & DQS internal Pullup/Pulldown settings\n"
-	"WRITE: 0xC0001004 0xD0677449\n"
+	"WRITE: 0xC0001004 0xD0133449\n"
 	"WRITE: 0xC0001008 0xC770055A\n"
 	"WRITE: 0xC000100C 0x5461DF77\n"
 	"\n"


### PR DESCRIPTION
I have an ESPRESSObin Ultra (A3720 DDR4 1CS 1GB) that is highly unstable unless this setting is put back to the original value it had prior to being modified by [this commit](https://github.com/MarvellEmbeddedProcessors/mv-ddr-marvell/commit/c3a8d3c7ff4bd460770b0cf601e57a6f70cb1871). There was no commit message associated with that change so the motivation for changing it is unclear. The distributor of the ESPRESSObin Ultra (Globalscale) also overrides this value in [their repos](https://github.com/globalscaletechnologies/A3700-utils-marvell/commit/feced21c4c343428eab2f99cc9c78028bb961690).