### PR TITLE
Makefile: fix GCC 13+ strict warnings for ATF builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ ECHO     = @echo
 OBJ_DIR ?= $(MV_DDR_ROOT)
 
 CFLAGS = -DMV_DDR_ATF -DCONFIG_DDR4
-CFLAGS += -Wall -Werror -Os -ffreestanding -mlittle-endian -g -gdwarf-2 -nostdinc
+CFLAGS += -Wall -Werror -Wno-error=array-parameter -Wno-error=array-bounds -Wno-error=format -Os -ffreestanding -mlittle-endian -g -gdwarf-2 -nostdinc
 CFLAGS += -march=armv8-a -fpie
 CFLAGS += $(call cc_option, --param=min-pagesize=0)
 


### PR DESCRIPTION
Add compiler flags to disable warnings treated as errors that break builds with GCC 13 and later:
- -Wno-error=array-parameter (mismatched array bounds in prototypes)
- -Wno-error=array-bounds (mmio access patterns)
- -Wno-error=format (uint64_t printf format on aarch64)

These warnings are false positives in the DDR training code and do not indicate actual bugs. The fix allows building with modern GCC versions while preserving -Werror for other warnings.