### PR TITLE
Makefile: support custom CFLAGS through EXTRA_CFLAGS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,9 @@ $(shell test "`cat $(OBJ_DIR)/a3700_ddr_type 2>/dev/null`" = "$(DDR_TYPE)" || ec
 
 CFLAGS += -DCONFIG_A3700 -DSILENT_LIB
 
+# Allow external build systems to pass custom CFLAGS
+CFLAGS += $(EXTRA_CFLAGS)
+
 MV_DDR_CSRC = $(foreach DIR,$(MV_DDR_SRCPATH),$(wildcard $(DIR)/*.c))
 MV_DDR_CSRC += $(MV_DDR_DRVPATH)/mv_ddr_mc6.c
 MV_DDR_CSRC += $(MV_DDR_ROOT)/mv_ddr4_training_db.c
@@ -417,6 +420,10 @@ INCLUDE = $(addprefix -I,$(INCPATH))
 INCLUDE += $(PLAT_INCLUDES)
 
 CFLAGS += $(INCLUDE)
+
+# Allow external build systems to pass custom CFLAGS
+CFLAGS += $(EXTRA_CFLAGS)
+
 #CFLAGS += -DCONFIG_MC_STATIC
 #CFLAGS += -DCONFIG_MC_STATIC_PRINT
 #CFLAGS += -DCONFIG_PHY_STATIC


### PR DESCRIPTION
Some build systems (like Buildroot) may need to pass additional compiler flags to handle toolchain-specific requirements. For example, toolchains that enable stack protection by default need to pass -fno-stack-protector since ATF does not provide the required __stack_chk routines.

Add support for EXTRA_CFLAGS variable following the Linux kernel pattern, allowing external build systems to pass custom compiler flags without patching the Makefile.