### PR TITLE
Fix GCC warnings and linker error for ATF builds when using SILENT_LIB

### DIFF
--- a/ddr3_debug.c
+++ b/ddr3_debug.c
@@ -110,6 +110,11 @@ void ddr3_hws_set_log_level(enum ddr_lib_debug_block block, u8 level)
 {
 	/* do nothing */
 }
+
+void mv_ddr_user_log_level_set(enum ddr_lib_debug_block block)
+{
+	/* do nothing */
+}
 #else /* SILENT_LIB */
 /* Debug flags for other Training modules */
 u8 debug_training_static = DEBUG_LEVEL_ERROR;

--- a/ddr3_training_centralization.c
+++ b/ddr3_training_centralization.c
@@ -401,6 +401,10 @@ static int ddr3_tip_centralization(u32 dev_num, u32 mode)
 						cur_end_win) -
 					ddr3_tip_get_buf_min(
 						cur_end_win);
+				/* suppress unused variable warnings when debug is disabled */
+				(void)waste_window;
+				(void)start_window_skew;
+				(void)end_window_skew;
 				/* min/max updated with pattern change */
 				cur_end_win_min =
 					ddr3_tip_get_buf_min(

--- a/ddr3_training_leveling.c
+++ b/ddr3_training_leveling.c
@@ -2114,6 +2114,11 @@ int mv_ddr_rl_dqs_burst(u32 dev_num, u32 if_id, u32 freq)
 		max_phase = (rl_max_val[effective_cs] - (sdr_cycle_incr * TAPS_PER_RD_SAMPLE)) % MAX_RD_SAMPLES;
 		final_rd_sample = rd_sample;
 		final_rd_ready = rd_ready;
+		/* suppress unused variable warnings when debug is disabled */
+		(void)min_phase;
+		(void)max_phase;
+		(void)final_rd_sample;
+		(void)final_rd_ready;
 
 		ddr3_tip_if_write(0, ACCESS_TYPE_UNICAST, 0, RD_DATA_SMPL_DLYS_REG,
 				  rd_sample << RD_SMPL_DLY_CS_OFFS(effective_cs),

--- a/mv_ddr4_training_calibration.c
+++ b/mv_ddr4_training_calibration.c
@@ -127,7 +127,7 @@ static u8 vdq_tv; /* vref value for dq vref calibration */
 static u8 duty_cycle; /* duty cycle value for receiver calibration */
 static u8 rx_vw_pos[MAX_INTERFACE_NUM][MAX_BUS_NUM];
 static u8 patterns_byte_status[MAX_INTERFACE_NUM][MAX_BUS_NUM];
-static const char *str_dir[MAX_DIR_TYPES] = {"read", "write"};
+static const char __attribute__((unused)) *str_dir[MAX_DIR_TYPES] = {"read", "write"};
 
 static u8 center_low_element_get(u8 dir, u8 pbs_element, u16 lambda, u8 pbs_max_val)
 {
@@ -634,6 +634,10 @@ static int mv_ddr4_centralization(u8 dev_num, u16 (*lambda)[MAX_BUS_NUM][BUS_WID
 					ddr3_tip_get_buf_min(curr_start_win);
 				end_win_skew = ddr3_tip_get_buf_max(curr_end_win) -
 					ddr3_tip_get_buf_min(curr_end_win);
+				/* suppress unused variable warnings when debug is disabled */
+				(void)waste_win;
+				(void)start_win_skew;
+				(void)end_win_skew;
 
 				/* min/max updated with pattern change */
 				curr_end_win_min = ddr3_tip_get_buf_min(curr_end_win);
@@ -1081,6 +1085,8 @@ static int mv_ddr4_center_of_mass_calc(u8 dev_num, u8 if_id, u8 subphy_num, u8 m
 	r_sq = s0 * (s0 / s1);
 	r_sq /= (s2 / 1000);
 	slope = s0 / s1;
+	/* suppress unused variable warning when debug is disabled */
+	(void)slope;
 
 	/* idx n is equal to idx 0 */
 	edge_t[vw_num * 2] = vw_l[0];


### PR DESCRIPTION
Add (void) casts, __attribute__((unused)), and stub functions to suppress compiler warnings when debug macros are disabled, and fix a linker error when SILENT_LIB is defined.

Fixes the following compilation errors with -Werror:

ddr3_training_centralization.c: In function 'ddr3_tip_centralization':
  ddr3_training_centralization.c:161:57: error: variable 'end_window_skew' set but not used [-Werror=unused-but-set-variable]
  ddr3_training_centralization.c:161:38: error: variable 'start_window_skew' set but not used [-Werror=unused-but-set-variable]
  ddr3_training_centralization.c:161:24: error: variable 'waste_window' set but not used [-Werror=unused-but-set-variable]

ddr3_training_leveling.c: In function 'mv_ddr_rl_dqs_burst':
  ddr3_training_leveling.c:1830:24: error: variable 'max_phase' set but not used [-Werror=unused-but-set-variable]
  ddr3_training_leveling.c:1830:13: error: variable 'min_phase' set but not used [-Werror=unused-but-set-variable]
  ddr3_training_leveling.c:1825:30: error: variable 'final_rd_ready' set but not used [-Werror=unused-but-set-variable]
  ddr3_training_leveling.c:1825:13: error: variable 'final_rd_sample' set but not used [-Werror=unused-but-set-variable]

mv_ddr4_training_calibration.c: In function 'mv_ddr4_centralization':
  mv_ddr4_training_calibration.c:444:49: error: variable 'end_win_skew' set but not used [-Werror=unused-but-set-variable]
  mv_ddr4_training_calibration.c:444:33: error: variable 'start_win_skew' set but not used [-Werror=unused-but-set-variable]
  mv_ddr4_training_calibration.c:444:22: error: variable 'waste_win' set but not used [-Werror=unused-but-set-variable]

mv_ddr4_training_calibration.c: In function 'mv_ddr4_center_of_mass_calc':
  mv_ddr4_training_calibration.c:1050:37: error: variable 'slope' set but not used [-Werror=unused-but-set-variable]

mv_ddr4_training_calibration.c: At top level:
  mv_ddr4_training_calibration.c:130:20: error: 'str_dir' defined but not used [-Werror=unused-variable]

Linker error (undefined reference to mv_ddr_user_log_level_set):
  ATF builds could pass -DSILENT_LIB which excluded mv_ddr_user_log_level_set
  from compilation, but ddr3_init.c still called it. Added stub function
  in the SILENT_LIB case.